### PR TITLE
Remove `requirePaddingNewLineAfterVariableDeclaration`

### DIFF
--- a/src/presets/seegno.json
+++ b/src/presets/seegno.json
@@ -19,7 +19,6 @@
   },
   "requireLineBreakAfterVariableAssignment": true,
   "requireMatchingFunctionName": true,
-  "requirePaddingNewLineAfterVariableDeclaration": true,
   "requirePaddingNewLinesAfterBlocks": {
     "allExcept": [
       "inCallExpressions",

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -34,11 +34,6 @@ const requireMatchingFunctionName = {};
 
 requireMatchingFunctionName.foo = function foo() {};
 
-// `requirePaddingNewLineAfterVariableDeclaration`.
-const requirePaddingNewLineAfterVariableDeclaration = { foo: 'bar' };
-
-requirePaddingNewLineAfterVariableDeclaration.foo = 'baz';
-
 // `requirePaddingNewLinesAfterBlocks` and `requirePaddingNewlinesBeforeKeywords`.
 function requirePaddingNewLinesAfterBlocks() {
   const foo = true;

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -35,10 +35,6 @@ const requireMatchingFunctionName = {};
 
 requireMatchingFunctionName.foo = function bar() {};
 
-// `requirePaddingNewLineAfterVariableDeclaration`.
-const requirePaddingNewLineAfterVariableDeclaration = { foo: 'bar' };
-requirePaddingNewLineAfterVariableDeclaration.foo = 'baz';
-
 // `requirePaddingNewLinesAfterBlocks` and `requirePaddingNewlinesBeforeKeywords`.
 function requirePaddingNewLinesAfterBlocks() {
   const foo = true;


### PR DESCRIPTION
This rule is already covered by our eslint config (see https://github.com/seegno/eslint-config-seegno/issues/53). So we can safely remove it from the jscs preset.
