### PR TITLE
Deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Deprecated. JSCS is moving to the ESLint team. Use [eslint-config-seegno](https://github.com/seegno/eslint-config-seegno) with ESLint.
+
 # jscs-preset-seegno
 Seegno-flavored JSCS preset.
 


### PR DESCRIPTION
Giving this project the same fate as [jscs-config-seegno](https://github.com/seegno/jscs-config-seegno). Its behaviour has been ported to [eslint-config-seegno](https://github.com/seegno/eslint-config-seegno), so it can safely be deprecated.
